### PR TITLE
env on delivery stream name removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ A package for creating metrics in Firehose
 
 ## Installation
 ```sh
-npm install @janiscommerce/metric
+npm install @janiscommerce/metrics
 ```
 
 ## Configuration
 ### ENV variables
 **`JANIS_SERVICE_NAME`** (required): The Role Session Name to assume role in order to put records in Firehose.
-**`JANIS_ENV`** (required): The stage name that will used as prefix for trace firehose delivery stream.
 **`METRIC_ROLE_ARN`** (required): The ARN to assume role in order to put records in Firehose.
 
 ## API

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -32,45 +32,6 @@ module.exports = class Metric {
 	}
 
 	/**
-	 * @static
-	 * @returns{object<string, string>} A key-value object of environments and their friendly name
-	 */
-	static get envs() {
-
-		return [
-			'local',
-			'beta',
-			'qa',
-			'prod'
-		];
-	}
-
-	/**
-	 * @static
-	 * @returns {string} The delivery stream name per environment to be used in Firehose
-	 */
-	static get deliveryStreamName() {
-
-		if(!this._deliveryStreamName)
-			this._deliveryStreamName = `${DELIVERY_STREAM_PREFIX}-${this.formattedEnv}`;
-
-		return this._deliveryStreamName;
-	}
-
-	/**
-	 * @static
-	 * @returns {string} The friendly name of the current env
-	 * @throws {MetricError} If current env is not defined or it's invalid
-	 */
-	static get formattedEnv() {
-
-		if(!this.envs.includes(this.env))
-			throw new MetricError('Unknown environment', MetricError.codes.NO_ENVIRONMENT);
-
-		return this.env;
-	}
-
-	/**
 	 * Returns the sls helpers needed for serverles configuration.
 	 *
 	 * @static
@@ -156,7 +117,7 @@ module.exports = class Metric {
 			metricPromises = await Promise.allSettled(
 				metricsBatches.map(metrics => firehose.putRecordBatch(
 					{
-						DeliveryStreamName: this.deliveryStreamName,
+						DeliveryStreamName: DELIVERY_STREAM_PREFIX,
 						Records: metrics.map(metric => ({
 							Data: Buffer.from(JSON.stringify(metric))
 						}))


### PR DESCRIPTION
Dejo ajustes que surgieron por pruebas en ambiente.

Detalle:

1. Se actualizo el README.
   a) Se agrego "s" al install
   b) Se elimino comentario de "JANIS_ENV" obligatorio.
2. Se quito toda la validación de ambiente
3. Se ajusto el DeliveryStreamName
4. Se ajustaron los test
5. No se va a cambiar el main de package.json dado que existe "get serverlessConfiguration()" en la lib
